### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ model.choose()
 model.isChosen() #=> true
 ```
 
-#### model.toggleChosen()
+#### model.toggleChoose()
 Toggles between chosen and unchosen
 
 ```coffee


### PR DESCRIPTION
Just fixing a quick typo in the README. Great plugin, thanks!
