### PR TITLE
Fix error in Multichooser.choose method

### DIFF
--- a/backbone-chooser.coffee
+++ b/backbone-chooser.coffee
@@ -130,7 +130,7 @@ do (Backbone) ->
 
       eventShouldTrigger = false
 
-      for model in _([args]).flatten()
+      for model in _([args]).flatten().value()
         ## break if the model is already chosen
         break if !@modelInChosen(model)
 

--- a/backbone-chooser.coffee
+++ b/backbone-chooser.coffee
@@ -112,7 +112,7 @@ do (Backbone) ->
 
       eventShouldTrigger = false
 
-      for model in _([args]).flatten()
+      for model in _([args]).flatten().value()
         ## break if the model is already chosen
         break if @modelInChosen(model)
 


### PR DESCRIPTION
The value() method needs to be called to get the result of chained operations, otherwise the wrapper will be returned instead and the cycle on the models will never run.
