### PR TITLE
For the empty collection 'collection:chose:none' event is triggered

### DIFF
--- a/backbone-chooser.coffee
+++ b/backbone-chooser.coffee
@@ -169,10 +169,10 @@ do (Backbone) ->
         @chooseById id, options
 
     _getEvent: ->
-      if @collection.length is @getChosen().length
-        return "collection:chose:all"
-
       if @getChosen().length is 0
         return "collection:chose:none"
+
+      if @collection.length is @getChosen().length
+        return "collection:chose:all"
 
       return "collection:chose:some"


### PR DESCRIPTION
If there is no model in the collection then event 'collection-chose-none' will be triggered. Not 'collection:chose:all' event
It is need when last model in the collection has been removed
